### PR TITLE
Add Langgraph agent for fruit and vegetable output

### DIFF
--- a/fruit_vegetable_agent.py
+++ b/fruit_vegetable_agent.py
@@ -1,0 +1,19 @@
+from langgraph.graph import StateGraph, END
+from langchain_core.runnables import RunnableLambda
+from typing_extensions import TypedDict
+
+class GraphState(TypedDict):
+    fruit: str
+    vegetable: str
+
+def output_fruit_vegetable(state: GraphState) -> GraphState:
+    return {"fruit": "apple", "vegetable": "eggplant"}
+
+def build_graph():
+    graph = StateGraph(GraphState)
+
+    graph.add_node("emit_fruit_vegetable", output_fruit_vegetable)
+    graph.set_entry_point("emit_fruit_vegetable")
+    graph.add_edge("emit_fruit_vegetable", END)
+
+    return graph.compile()


### PR DESCRIPTION
This PR adds a new Langgraph agent that generates a JSON output containing fruit and vegetable data.

## Changes
- Created `fruit_vegetable_agent.py` with a Langgraph agent implementation
- The agent outputs `{'fruit': 'apple', 'vegetable': 'eggplant'}` as specified
- Follows the same pattern as the sample agent with appropriate state management

## Implementation Details
- Uses `GraphState` TypedDict to define the expected output structure
- Implements `output_fruit_vegetable` function to return the required data
- Creates a simple graph with one node that emits the fruit and vegetable data
- Graph is compiled and ready for execution

The agent follows the established pattern from the sample code and will generate the expected JSON output when executed.