### PR TITLE
Refactor LangGraph implementation to simplify fruit dictionary generation

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -3,36 +3,21 @@ from typing import TypedDict
 import json
 
 class GraphState(TypedDict):
-    data: dict
+    result: dict
 
-def add_apple(state: GraphState) -> GraphState:
-    state["data"]["apple"] = 1
-    return state
+def generate_fruit_dict(state: GraphState) -> GraphState:
+    return {"result": {"apple": 1, "banana": 2, "cherry": 3}}
 
-def add_banana(state: GraphState) -> GraphState:
-    state["data"]["banana"] = 2
-    return state
-
-def add_cherry(state: GraphState) -> GraphState:
-    state["data"]["cherry"] = 3
-    return state
-
-def build_graph():
+def create_graph():
     workflow = StateGraph(GraphState)
     
-    workflow.add_node("apple", add_apple)
-    workflow.add_node("banana", add_banana)
-    workflow.add_node("cherry", add_cherry)
-    
-    workflow.set_entry_point("apple")
-    workflow.add_edge("apple", "banana")
-    workflow.add_edge("banana", "cherry")
-    workflow.add_edge("cherry", END)
+    workflow.add_node("generate", generate_fruit_dict)
+    workflow.set_entry_point("generate")
+    workflow.add_edge("generate", END)
     
     return workflow.compile()
 
 if __name__ == "__main__":
-    graph = build_graph()
-    initial_state = {"data": {}}
-    result = graph.invoke(initial_state)
-    print(json.dumps(result["data"]))
+    graph = create_graph()
+    result = graph.invoke({"result": {}})
+    print(json.dumps(result["result"]))


### PR DESCRIPTION
This PR refactors the LangGraph implementation to generate the target JSON `{apple: 1, banana: 2, cherry: 3}` more efficiently.

## Changes Made:
- **Simplified state structure**: Changed from `data` to `result` key in GraphState
- **Consolidated logic**: Replaced three separate node functions (`add_apple`, `add_banana`, `add_cherry`) with a single `generate_fruit_dict` function
- **Streamlined graph**: Reduced from a 3-node sequential workflow to a single-node workflow
- **Improved function naming**: Renamed `build_graph()` to `create_graph()` for better clarity
- **Optimized execution**: Eliminated unnecessary sequential processing while maintaining the same output

## Benefits:
- Reduced code complexity and maintenance overhead
- Improved performance by eliminating unnecessary graph traversal
- Cleaner, more readable codebase
- Same functional output with simpler implementation

The refactored code produces the exact same target JSON output while being more concise and efficient.