### PR TITLE
Simplify LangGraph implementation to generate fruit dictionary

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -2,37 +2,20 @@ from langgraph.graph import StateGraph, END
 from typing import TypedDict
 import json
 
-class GraphState(TypedDict):
-    data: dict
+class State(TypedDict):
+    result: dict
 
-def add_apple(state: GraphState) -> GraphState:
-    state["data"]["apple"] = 1
-    return state
+def generate_fruit_dict(state: State) -> State:
+    return {"result": {"apple": 1, "banana": 2, "cherry": 3}}
 
-def add_banana(state: GraphState) -> GraphState:
-    state["data"]["banana"] = 2
-    return state
-
-def add_cherry(state: GraphState) -> GraphState:
-    state["data"]["cherry"] = 3
-    return state
-
-def build_graph():
-    workflow = StateGraph(GraphState)
-    
-    workflow.add_node("apple", add_apple)
-    workflow.add_node("banana", add_banana)
-    workflow.add_node("cherry", add_cherry)
-    
-    workflow.set_entry_point("apple")
-    workflow.add_edge("apple", "banana")
-    workflow.add_edge("banana", "cherry")
-    workflow.add_edge("cherry", END)
-    
+def create_graph():
+    workflow = StateGraph(State)
+    workflow.add_node("generate", generate_fruit_dict)
+    workflow.set_entry_point("generate")
+    workflow.add_edge("generate", END)
     return workflow.compile()
 
 if __name__ == "__main__":
-    graph = build_graph()
-    initial_state = {"data": {}}
-    result = graph.invoke(initial_state)
-    print(json.dumps(result["data"]))
+    graph = create_graph()
+    result = graph.invoke({"result": {}})
+    print(json.dumps(result["result"]))


### PR DESCRIPTION
This PR refactors the LangGraph implementation to generate the target JSON `{apple: 1, banana: 2, cherry: 3}` in a more efficient and streamlined way.

## Changes Made:
- **Simplified state structure**: Renamed `GraphState` to `State` and changed `data` field to `result` for clarity
- **Consolidated node logic**: Replaced three separate nodes (`add_apple`, `add_banana`, `add_cherry`) with a single `generate_fruit_dict` node that creates the complete dictionary in one step
- **Streamlined graph structure**: Simplified the workflow from a sequential 3-node chain to a single-node execution
- **Cleaner function naming**: Renamed `build_graph()` to `create_graph()` for better naming convention
- **Maintained output format**: The final JSON output remains exactly the same as required

## Benefits:
- Reduced code complexity and maintenance overhead
- Improved performance by eliminating unnecessary sequential processing
- Cleaner, more readable codebase
- Same functional output with simpler implementation

The refactored code still produces the exact target JSON when executed while being more maintainable and efficient.