### PR TITLE
Add graph.py to generate target fruit dictionary JSON

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -1,0 +1,8 @@
+import json
+
+def create_fruit_dict():
+    return {"apple": 1, "banana": 2, "cherry": 3}
+
+if __name__ == "__main__":
+    result = create_fruit_dict()
+    print(json.dumps(result))


### PR DESCRIPTION
This PR adds a new `graph.py` file that generates the required target JSON output: `{"apple": 1, "banana": 2, "cherry": 3}`.

## Changes
- Created `graph.py` with a `create_fruit_dict()` function that returns the target dictionary
- Added main execution block that prints the JSON output when the script is run
- Used proper JSON formatting with `json.dumps()` for consistent output

## Testing
Run `python graph.py` to verify it produces the exact target JSON output.